### PR TITLE
Fix new response on error

### DIFF
--- a/lib/Role/REST/Client/Response.pm
+++ b/lib/Role/REST/Client/Response.pm
@@ -13,6 +13,7 @@ has 'response' => (
 has 'error' => (
 	isa => 'Str',
 	is  => 'ro',
+        predicate => 'failed',
 );
 has 'data_callback' => (
 	init_arg => 'data',


### PR DESCRIPTION
The response's 'error' should only be filled in case of fatal error.
Additionally, create the 'failed' predicate for this attr.
