### PR TITLE
Failing tests

### DIFF
--- a/t/rest.t
+++ b/t/rest.t
@@ -1,4 +1,5 @@
 use Test::More;
+use Test::Deep;
 use MooseX::Declare;
 use HTTP::Response;
 use HTTP::Headers;
@@ -28,10 +29,12 @@ my $ua_class = class {
   }
 };
 my $ua = $ua_class->name->new(timeout => 5);
+my $persistent_headers = { 'Accept' => 'application/json' };
 my %testdata = (
 	server => 'http://localhost:3000',
 	type => 'application/x-www-form-urlencoded',
 	user_agent => $ua,
+        persistent_headers => $persistent_headers,
 );
 ok(my $obj = RESTExample->new(%testdata), 'New object');
 isa_ok($obj, 'RESTExample');
@@ -40,9 +43,35 @@ for my $item (qw/post get put delete _call httpheaders/) {
     ok($obj->can($item), "Role method $item exists");
 }
 
+is_deeply($obj->httpheaders, $persistent_headers,
+  'headers should include persistent ones since first request');
 ok(my $res = $obj->bar, 'got a response object');
+is_deeply($obj->httpheaders, $persistent_headers,
+  'after first request, it contains persistent ones');
 isa_ok($res, 'Role::REST::Client::Response');
 isa_ok($res->response, 'HTTP::Response');
 is($res->data->{'error'}, 'Resource not found', 'deserialization works');
+
+$obj->set_header('X-Foo', 'foo');
+is_deeply($obj->httpheaders, {
+  %$persistent_headers,
+  'X-Foo', 'foo',
+});
+
+$obj->reset_headers; # which would be like ->httpheaders($persistent_headers);
+is_deeply($obj->httpheaders, $persistent_headers,
+  'should have at least persistent_headers');
+
+$obj->clear_headers;
+is_deeply($obj->httpheaders, {}, 'new fresh httpheaders without persistent ones');
+
+ok($obj = RESTExample->new({ %testdata, httpheaders => { 'X-Foo' => 'foo' } }));
+is_deeply($obj->httpheaders, {
+  %$persistent_headers,
+  'X-Foo', 'foo',
+}, 'merge httpheaders with persistent_headers');
+ok($res = $obj->bar, 'got a response object');
+is_deeply($obj->httpheaders, $persistent_headers,
+  'after first request, it contains persistent ones');
 
 done_testing;


### PR DESCRIPTION
...for proposal API and showing bug for missing persistent_headers at first request.

Test at line 125 passes, but not at 121. I was considering ->httpheaders($persistent_headers) as a reset action, then you could rename the writer to be private for that attr and create a reset_headers thing which would do ->_set_htttpheaders($persistent_headers).
