### PR TITLE
update dist.ini prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,17 +24,20 @@ repository.type = git
 ;[Signature]
 [CheckChangeLog]
 [AutoPrereqs]
+[Prereqs / Runtime]
+HTTP::Message = 0
+Data::Serializer::Raw = 0
 [Prereqs / TestRequires]
 Test::More = 0.88
-Data::Serializer::Raw = 0
+MooseX::Declare = 0
+[Prereqs / Recommends]
+-relationship = recommends
 Data::Serializer::JSON = 0
 Data::Serializer::YAML = 0
 Data::Serializer::XML::Simple = 0
 JSON = 2.00
 YAML = 0
 XML::Simple = 0
-MooseX::Declare = 0
-HTTP::Message = 0
 [PkgVersion]
 
 [Git::Tag]


### PR DESCRIPTION
Change json/yaml/xml serializers to recommends instead of requires. Not all are needed to consume the role. Let the user choose which need to be installed.
