### PR TITLE
A number of doc improvements, fixes #15 and addresses #16

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Role-REST-Client
 
 {{$NEXT}}
 
+ - Improved Docs (Mark Stosberg) 
+
 0.13    2012-11-11 12:45:40 Europe/Copenhagen
  -  Change json/yaml/xml serializers to recommends instead of requires (Matt Phillips)
  -  Fix httpheaders attr - must be lazy since builder depends on persistent_headers (Wallace Reis).

--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -83,6 +83,9 @@ sub reset_headers {my $self = shift;$self->_set_httpheaders({ %{$self->persisten
 
 sub _rest_response_class { 'Role::REST::Client::Response' }
 
+# If the response is a hashref, we expect it to be in the format returned by
+# HTTP::Tiny->request() and convert it to an HTTP::Response object.  Otherwise,
+# pass the response through unmodified.
 sub _handle_response {
 	my ( $self, $res ) = @_;
 	if ( ref $res eq 'HASH' ) {
@@ -303,29 +306,48 @@ All methods return a response object dictated by _rest_response_class. Set to L<
 
 =head2 user_agent
 
-An UA object which can do C<< ->request >> method, for instance: L<HTTP::Tiny>, L<LWP::UserAgent>, etc.
+  sub _build_user_agent { HTTP::Tiny->new }
+
+A User Agent object which has a C<< ->request >> method suitably compatible with L<HTTP::Tiny>. It should accept arguments like this: C<< $ua->request($method, $uri, $opts) >>, and needs to return a hashref as HTTP::Tiny does, or an L<HTTP::Response> object.  To set your own default, use a C<_build_user_agent> method.
 
 =head2 server
 
-Url of the REST server.
+URL of the REST server.
 
 e.g. 'http://localhost:3000'
 
 =head2 type
 
-Mime content type,
+MIME Content-Type header,
 
 e.g. application/json
 
 =head2 httpheaders
+
+  $self->set_header('Header' => 'foo', ... );
+  $self->get_header('Header-Name');
+  $self->has_no_headers;
+  $self->clear_headers;
 
 You can set any http header you like with set_header, e.g.
 $self->set_header($key, $value) but the content-type header will be overridden.
 
 =head2 persistent_headers
 
-A hashref containing headers you want to use for all requests. Set individual headers with
-set_persistent_header, clear the hashref with clear_persistent_header.
+  $self->set_persistent_header('Header' => 'foo', ... );
+  $self->get_persistent_header('Header-Name');
+  $self->has_no_persistent_headers;
+  $self->clear_persistent_headers;
+
+A hashref containing headers you want to use for all requests. Use the methods
+described above to manipulate it.
+
+To set your own defaults, override the default or call C<set_persistent_header()> in your
+C<BUILD> method.
+
+  has '+persistent_headers' => (
+    default => sub { ... },
+  );
 
 =head2 clientattrs
 

--- a/lib/Role/REST/Client/Response.pm
+++ b/lib/Role/REST/Client/Response.pm
@@ -33,19 +33,29 @@ __END__
 
 Role::REST::Client::Response - Response class for REST
 
-=head1 METHODS
+=head1 SYNOPSIS
+
+    my $res = Role::REST::Client::Response->new(
+        code          => '200',
+        response      => HTTP::Response->new(...),
+        error         => 0,
+        data_callback => sub { sub { ... } },
+    );
+
+=head1 ATTRIBUTES
 
 =head2 code
 
-Returns the http status code of the request
+HTTP status code of the request
 
 =head2 response
 
-Returns the a HTTP::Response object. Use this if you need more information than status and content.
+L<HTTP::Response> object. Use this if you need more information than status and content.
 
 =head2 error
 
-Returns the returned reason from HTTP::Tiny where the status is 500 or higher. 
+The returned reason from L<HTTP::Tiny> where the status is 500 or higher. More detail may be provided 
+by calling C<< $res->response->content >>.
 
 =head2 failed
 
@@ -53,21 +63,21 @@ True if the request didn't succeed.
 
 =head2 data
 
-Returns the deserialized data. Returns an empty hashref if the response was unsuccessful
+The deserialized data. Returns an empty hashref if the response was unsuccessful.
 
 =head1 AUTHOR
 
 Kaare Rasmussen, <kaare at cpan dot com>
 
-=head1 BUGS 
+=head1 BUGS
 
 Please report any bugs or feature requests to bug-role-rest-client at rt.cpan.org, or through the
 web interface at http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Role-REST-Client.
 
-=head1 COPYRIGHT & LICENSE 
+=head1 COPYRIGHT & LICENSE
 
 Copyright 2012 Kaare Rasmussen, all rights reserved.
 
-This library is free software; you can redistribute it and/or modify it under the same terms as 
-Perl itself, either Perl version 5.8.8 or, at your option, any later version of Perl 5 you may 
+This library is free software; you can redistribute it and/or modify it under the same terms as
+Perl itself, either Perl version 5.8.8 or, at your option, any later version of Perl 5 you may
 have available.


### PR DESCRIPTION
- Suitable alternatives for HTTP::Tiny have been further clarified
  - When "default" or "builder" have been used, it's important to
    communicat which has been done, so people can override it. If you
    use a different option then the role you are consuming, Moose
    throws an exception about a conflict between 'default' and
    'builder'.
  - Methods available for managing headers have more complete
    documentation
  - Synopsis and other touch-ups for Role::REST::Client docs
  - Some minor whitespace clean-ups as well. (Removing a bit of
    end-of-line whitespace)
