### PR TITLE
Fix URI encode process

### DIFF
--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -2,7 +2,7 @@ package Role::REST::Client;
 
 use Moose::Role;
 use Moose::Util::TypeConstraints;
-use URI::Escape;
+use URI::Escape::XS 'uri_escape';
 use Try::Tiny;
 
 use Carp qw(confess);


### PR DESCRIPTION
For GET requests, the query params must be correctly encoded and the
urlencoded_data method is not handling utf8 strings.
