### PR TITLE
prevent 'redefined' warnings and updated dependency list

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Role-REST-Client
 
 {{$NEXT}}
+ - Prevent 'redefined' warnings and updated dependency list (Breno G. de Oliveira)
 
 0.16    2013-09-26 07:51:17 Europe/Copenhagen
  - Mooify Role::REST::Client (Matt Phillips)

--- a/dist.ini
+++ b/dist.ini
@@ -30,6 +30,7 @@ Data::Serializer::Raw = 0
 Moo = 1.003000
 MooX::HandlesVia = 0.001004
 Type::Tiny = 0.024
+URI::Escape::XS = 0.11
 [Prereqs / TestRequires]
 Data::Serializer::JSON = 0
 Data::Serializer::YAML = 0

--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -5,7 +5,6 @@ use MooX::HandlesVia;
 use Types::Standard qw(HashRef Str Int Enum HasMethods);
 
 use HTTP::Tiny;
-use URI::Escape;
 use URI::Escape::XS 'uri_escape';
 use Try::Tiny;
 use Carp qw(confess);


### PR DESCRIPTION
Hi there! Thanks for this very useful role =)

It appears git messed up while accepting different merge requests, and the URI::Escape that was removed in a previous commit got suddenly re-added. As such, every time the module loaded it issues a warning about the 'uri_escape' function being redefined.

This patches fixes the issue, while also adding a (previously missing) entry in dist.ini for URI::Escape::XS.
