### PR TITLE
Fix "Use of uninitialized value in concatenation (.) or string" in GET

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Role-REST-Client
 {{$NEXT}}
  - The standard is not clear on this, and some servers don't allow them, but it seems that DELETE can take a request body.
  - Added serializer_options so it's possible to instantiate the serializer w/ parameters
+ - Fixed "Use of uninitialized value in concatenation (.) or string" warning from GET
 
 0.18    2014-06-26 22:28:12 Europe/Copenhagen
  - Decode the content even for http codes >= 400. There might be some information there (idea: moltar)

--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -152,6 +152,8 @@ sub do_request {
 
 sub _call {
 	my ($self, $method, $endpoint, $data, $args) = @_;
+
+    $endpoint ||= ''; # Remove "Use of uninitialized value in concatenation (.) or string" warning
 	my $uri = $self->server.$endpoint;
 	# If no data, just call endpoint (or uri if GET w/parameters)
 	# If data is a scalar, call endpoint with data as content (POST w/parameters)


### PR DESCRIPTION
When calling $obj->GET(), I consistently get a warning "Use of uninitialized value in concatenation (.) or string". This is due to GET calling _request_with_query, which in turn calls $obj->_call('GET', **undef**, ...).

This patch corrects that oversight.