### PR TITLE
Correct author's email address

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Role-REST-Client
-author  = Kaare Rasmussen <kaare at cpan dot net>
+author  = Kaare Rasmussen <kaare at cpan dot org>
 license = Perl_5
 copyright_holder = Kaare Rasmussen
 


### PR DESCRIPTION
Correct author email address from @cpan.net to @cpan.org (I believe this is correct).  This relates to issue #28 