### PR TITLE
Conditional serializer

### DIFF
--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -295,6 +295,11 @@ Currently Role::REST::Client supports these encodings
 
 x-www-form-urlencoded only works for GET and POST, and only for encoding, not decoding.
 
+Responses which claim to not be serialised data (eg C<text/plain>,
+C<application/octet-stream>) will by default not be serialised. When the
+response is none of these, and it is impossible to determine what encoding is
+used, the content will be treated as JSON by default.
+
 =head1 METHODS
 
 =head2 methods
@@ -324,7 +329,11 @@ args - the optional argument parameter can have these entries
 
 	deserializer - if you KNOW that the content-type of the response is incorrect,
 	you can supply the correct content type, like
+
 	my $res = $self->post('/foo/bar/baz', {foo => 'bar'}, {deserializer => 'application/yaml'});
+
+	Alternatively, if you KNOW that the response is not serial data, you can
+	disable deserialization by setting this to undef.
 
 	preserve_headers - set this to true if you want to keep the headers between calls
 

--- a/t/conditional_deserialization.t
+++ b/t/conditional_deserialization.t
@@ -1,0 +1,95 @@
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::More;
+use Test::TCP;
+use Test::Warnings 'warning';
+use Try::Tiny;
+
+{
+	package My::REST::Client;
+	use Moo;
+	with 'Role::REST::Client';
+	1;
+}
+
+{
+	package My::TCP::Server;
+
+	use parent qw( Plack::Component );
+
+	use Plack::Request;
+
+	sub call {
+		my ($self, $env) = @_;
+		my $req = Plack::Request->new($env);
+
+		my $content_type = $env->{REQUEST_URI} =~ /json/i
+			? 'application/json'
+				: $env->{REQUEST_URI} =~ /html/i
+				? 'text/html' : 'text/plain';
+
+		return [
+			200,
+			[ 'Content-Type' => $content_type ],
+			[ '{"foo":"bar"}' ],
+		];
+	}
+	1;
+}
+
+use Plack::Runner;
+
+my $host = '127.0.0.1';
+
+my $server = try {
+	Test::TCP->new(
+		host => $host,
+		max_wait => 3, # seconds
+		code => sub {
+			my $port = shift;
+			my $runner = Plack::Runner->new;
+			$runner->parse_options(
+				'--host'   => $host,
+				'--port'   => $port,
+				'--env'    => 'test',
+				'--server' => 'HTTP::Server::PSGI'
+			);
+			$runner->run(My::TCP::Server->new->to_app);
+		}
+	);
+}
+catch {
+  plan skip_all => $_;
+};
+
+my $url = "http://$host:" . $server->port;
+my $client = My::REST::Client->new;
+
+# text/plain with specific undef: no deserialization
+ok !ref($client->get("$url/plain", undef, {deserializer => undef })->data),
+	'plain with undef';
+
+# text/plain with default: no deserialization
+ok !ref($client->get("$url/plain")->data), 'plain with default';
+
+# text/plain with specific deserializer: deserialize
+is ref($client->get(
+	"$url/plain", undef, { deserializer => 'application/json'})->data), 'HASH',
+	"plain with specific deserializer";
+
+# application/json with undef deserializer: no deserialization
+ok !ref($client->get("$url/json", undef, { deserializer => undef})->data),
+	"json with undef";
+
+# application/json with specific deserializer: deserialize
+is ref($client->get(
+	"$url/json", undef, { deserializer => 'application/json'})->data), 'HASH',
+	"json with specific deserializer";
+
+# application/json with default: deserialize
+is ref($client->get("$url/json")->data), 'HASH', "json with default";
+
+undef $server;
+done_testing();


### PR DESCRIPTION
This patch makes it possible to conditionally disable deserialization altogether. This is useful for cases when given API endpoints return raw text or binary blobs. In particular, this is needed to cleanly solve [#5 in GitLab::API::v3](https://github.com/bluefeet/GitLab-API-v3/issues/5).

The heuristic introduced by this patch is the following:

1. If the user specifies a deserializer, use that one (this doesn't change)
2. If the user specifically sets the deserializer to `undef`, then **deserialization is disabled**
3. If the content-type of the response is not serialized data (eg. `text/plain`, `text/html`, `application/octet-stream`, etc), then **deserialization is disabled**

The included tests should provide examples of how this would work.

The check for appropriate content-types could probably be improved.