### PR TITLE
Make sure response has a content type before checking

### DIFF
--- a/lib/Role/REST/Client.pm
+++ b/lib/Role/REST/Client.pm
@@ -168,7 +168,8 @@ sub _call {
 
 	my $use_serializer = exists $args->{deserializer}
 		? defined $args->{deserializer} ? 1 : 0
-		: $res->header('Content-Type') !~ m{(?:text/(?:plain|html)|application/octet-stream)};
+		: ($res->header('Content-Type')
+		  and $res->header('Content-Type') !~ m{(?:text/(?:plain|html)|application/octet-stream)});
 
 	my $deserializer_cb = sub {
 		# Try to find a serializer for the result content


### PR DESCRIPTION
When attempting to determine whether a deserialiser should be used for a particular call, R:R:Client falls back on checking the content-type header in the response against a regular expression.

However, [the `Content-Type` header is not mandatory](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1), and some endpoints,particularly those responding with `204 No Content`, might not set it.

In these cases, R:R:Client will issue a warning about uninitialized values being used in a pattern match. This patch fixes this.
